### PR TITLE
Allow using qualified column names

### DIFF
--- a/src/Traits/getColumns.php
+++ b/src/Traits/getColumns.php
@@ -13,7 +13,12 @@ trait getColumns
         $this->columns = $this->columns ??
             $this->getConnection()->getSchemaBuilder()->getColumnListing($this->getTable());
 
-        return $this->columns;
+        // allow using qualified column names
+        $qualifiedColumns = collect($this->columns)
+                ->map(fn($column) => $this->qualifyColumn($column))
+                ->toArray();
+
+        return array_merge($this->columns, $qualifiedColumns);
     }
 
     private function realName(array $fields, string $field): string


### PR DESCRIPTION
Potential fix for #25 allows using qualified column names in filters and prevent ambiguous column errors.