### PR TITLE
This feature provide ability to limit filtering by field."

### DIFF
--- a/src/Exceptions/OperatorNotSupported.php
+++ b/src/Exceptions/OperatorNotSupported.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Abbasudo\Purity\Exceptions;
+
+use InvalidArgumentException;
+
+class OperatorNotSupported extends InvalidArgumentException
+{
+    public static function create(string $field, string $operator, array $supportedOperators)
+    {
+        return new static(
+            "The operator {$operator} is not supported for the field {$field} supported operators : "
+            . implode(', ', $supportedOperators)
+        );
+    }
+}

--- a/src/Filters/Resolve.php
+++ b/src/Filters/Resolve.php
@@ -4,6 +4,7 @@ namespace Abbasudo\Purity\Filters;
 
 use Abbasudo\Purity\Exceptions\FieldNotSupported;
 use Abbasudo\Purity\Exceptions\NoOperatorMatch;
+use Abbasudo\Purity\Exceptions\OperatorNotSupported;
 use Closure;
 use Exception;
 use Illuminate\Database\Eloquent\Builder;
@@ -207,6 +208,7 @@ class Resolve
                 $this->model = $this->model->$relation()->getRelated();
             }
             $this->validateField($field);
+            $this->validateOperator($field, $subField);
 
             $this->fields[] = $this->model->getField($field);
             $this->filter($query, $subField, $subFilter);
@@ -226,5 +228,22 @@ class Resolve
         if (!in_array($field, $availableFields)) {
             throw FieldNotSupported::create($field, $this->model::class, $availableFields);
         }
+    }
+
+    /**
+     * @param  string  $field
+     * @param  string  $operator
+     * @return void
+     */
+    private function validateOperator(string $field, string $operator): void
+    {
+
+        $availableFilters = $this->model->getAvailableFiltersFor($field);
+
+        if (!$availableFilters || in_array($operator, $availableFilters)) {
+            return;
+        }
+
+        throw OperatorNotSupported::create($field, $operator, $availableFilters);
     }
 }

--- a/src/Traits/Filterable.php
+++ b/src/Traits/Filterable.php
@@ -7,6 +7,7 @@ use Abbasudo\Purity\Filters\Resolve;
 use Exception;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use ReflectionClass;
 

--- a/src/Traits/Filterable.php
+++ b/src/Traits/Filterable.php
@@ -7,6 +7,7 @@ use Abbasudo\Purity\Filters\Resolve;
 use Exception;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
 use ReflectionClass;
 
 /**
@@ -99,7 +100,38 @@ trait Filterable
      */
     public function availableFields(): array
     {
-        return $this->filterFields ?? array_merge($this->getTableColumns(), $this->relations());
+        if (!isset($this->filterFields)) {
+            return array_merge($this->getTableColumns(), $this->relations());
+        }
+
+        return $this->getUserDefinedFilterFields();
+    }
+
+    /**
+     * Get formatted fields from filterFields
+     * @return array
+     */
+    public function getUserDefinedFilterFields(): array
+    {
+        if (isset($this->userDefinedFilterFields)) {
+            return $this->userDefinedFilterFields;
+        }
+
+        $userDefinedFilterFields = [];
+
+        foreach ($this->filterFields as $key => $value) {
+            if (is_int($key)) {
+                if (Str::contains($value, ':')) {
+                    $userDefinedFilterFields[] = str($value)->before(':')->squish()->toString();
+                } else {
+                    $userDefinedFilterFields[] = $value;
+                }
+            } else {
+                $userDefinedFilterFields[] = $key;
+            }
+        }
+
+        return $this->userDefinedFilterFields = $userDefinedFilterFields;
     }
 
     /**

--- a/src/Traits/Filterable.php
+++ b/src/Traits/Filterable.php
@@ -209,4 +209,16 @@ trait Filterable
 
         return $query;
     }
+
+    /**
+     * @param  Builder  $query
+     * @param  array|string  $restrictedFilters
+     * @return Builder
+     */
+    public function scopeRestrictedFilters(Builder $query, array|string $restrictedFilters): Builder
+    {
+        $this->restrictedFilters = Arr::wrap($restrictedFilters);
+
+        return $query;
+    }
 }

--- a/tests/Feature/RestrictFilterableFieldsTest.php
+++ b/tests/Feature/RestrictFilterableFieldsTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use Abbasudo\Purity\Tests\Models\Post;
+use Abbasudo\Purity\Tests\TestCase;
+use Illuminate\Support\Facades\Route;
+use function PHPUnit\Framework\assertEquals;
+use function PHPUnit\Framework\assertTrue;
+
+class RestrictFilterableFieldsTest extends TestCase
+{
+
+    /** @test */
+    public function it_return_all_available_fields_when_filter_fields_not_defined(): void
+    {
+        $post = new Post();
+
+        $availableFields = $post->availableFields();
+        $expectedFields = ['title', 'created_at', 'updated_at'];
+
+        foreach ($expectedFields as $field) {
+            assertTrue(in_array($field, $availableFields));
+        }
+    }
+
+    /** @test */
+    public function it_return_all_available_fields_when_filter_fields_defined(): void
+    {
+        $post = new Post();
+        $post->filterFields = [
+            'title :$gt, $lt',
+            'status',
+            'description' => ['$ne', '$ecs'],
+            'rank' => '$eq',
+        ];
+
+        $availableFields = $post->availableFields();
+
+        assertEquals([
+            'title',
+            'status',
+            'description',
+            'rank',
+        ], $availableFields);
+    }
+}
+

--- a/tests/Feature/RestrictFilterableFieldsTest.php
+++ b/tests/Feature/RestrictFilterableFieldsTest.php
@@ -42,5 +42,68 @@ class RestrictFilterableFieldsTest extends TestCase
             'rank',
         ], $availableFields);
     }
+
+    /** @test */
+    public function it_can_return_restricted_filters_when_defined_inside_filter_fields()
+    {
+        $post = new Post();
+        $post->filterFields = [
+            'title : $gt,$lt',
+            'status',
+            'description' => ['$ne', '$ecs'],
+            'rank' => '$eq',
+        ];
+
+        $restrictedFilters = $post->getRestrictedFilters();
+
+        assertEquals([
+            'title' => ['$gt', '$lt'],
+            'description' => ['$ne', '$ecs'],
+            'rank' => ['$eq'],
+        ], $restrictedFilters);
+    }
+
+    /** @test */
+    public function it_gives_priority_to_restricted_filters_property_when_defined_to_return_restricted_filters()
+    {
+        $post = new Post();
+        $post->filterFields = [
+            'title : $gt,$lt',
+            'status',
+            'description' => ['$ne', '$ecs'],
+            'rank' => '$eq',
+        ];
+
+        $post->restrictedFilters = [
+            'title : $gte,$lte',
+            'status',
+            'description' => ['$ne'],
+            'rank' => ['$eq', 'lt'],
+        ];
+
+        $restrictedFilters = $post->getRestrictedFilters();
+
+        assertEquals([
+            'title' => ['$gte', '$lte'],
+            'description' => ['$ne'],
+            'rank' => ['$eq', 'lt'],
+        ], $restrictedFilters);
+    }
+
+    /** @test */
+    public function it_return_empty_array_when_no_restricted_property_is_defined()
+    {
+        $post = new Post();
+        $post->filterFields = [
+            'title',
+            'status',
+            'description',
+            'rank',
+        ];
+
+        $restrictedFilters = $post->getRestrictedFilters();
+
+        assertEquals([], $restrictedFilters);
+    }
 }
 


### PR DESCRIPTION
This feature adds the ability to restrict filter fields to predefined filter operations. While this is a useful package, I have noticed some defects, and one of them pertains to this feature. Allowing a field to apply any allowed filter operation could be a security vulnerability, as end-users might access data that the system doesn't intend to expose.

This is how it works,
There are three options available.

- Option 01 : Define restricted filters inside filter fields, as shown below:
 ```php
  $filterFields = [
                      'title' => ['eq'],  // title will be limited to the eq operator
                      'title' => 'eq',    // works only for one restricted operator
                      'title,eq' ,         // same as above
                      'title' ,            // this won't be restricted to any operator
                  ];
```
The disadvantage here is that you have to define all the allowed fields, disregarding the restricted ones.

- Option 2 : Define the restricted filters property
```php
$restrictedFields = [
    'title' => ['eq'], // title will be limited to the eq operator
    'title,eq'          // same as above
    'title'             // this won't be restricted to any operator
];
```
- Option 3 : Finally, you can set it on the Eloquent builder, which takes the highest priority:
```php
Post::restrictedFilters(['title' => ['eq']])->filter()->get();
```