### PR TITLE
Nested Relationship Fix

### DIFF
--- a/src/Filters/Resolve.php
+++ b/src/Filters/Resolve.php
@@ -217,7 +217,7 @@ class Resolve
             $this->filter($query, $subField, $subFilter);
         }
         array_pop($this->fields);
-        if(count($this->previousModels) > 0) {
+        if(count($this->previousModels)) {
             $this->model = end($this->previousModels);
             array_pop($this->previousModels);
         }

--- a/src/Filters/Resolve.php
+++ b/src/Filters/Resolve.php
@@ -27,6 +27,8 @@ class Resolve
     private FilterList $filterList;
 
     private Model $model;
+    
+    private array $previousModels = [];
 
     /**
      * @param FilterList $filterList
@@ -205,6 +207,7 @@ class Resolve
         foreach ($filters as $subField => $subFilter) {
             $relation = end($this->fields);
             if ($relation !== false) {
+                array_push($this->previousModels, $this->model);
                 $this->model = $this->model->$relation()->getRelated();
             }
             $this->validateField($field);
@@ -214,6 +217,10 @@ class Resolve
             $this->filter($query, $subField, $subFilter);
         }
         array_pop($this->fields);
+        if(count($this->previousModels) > 0) {
+            $this->model = end($this->previousModels);
+            array_pop($this->previousModels);
+        }
     }
 
     /**


### PR DESCRIPTION
There is a small issue this nested relationships. If we have a 'car_make', with relationship to  'car' and 'owner' tables. if we are filtering on car_make:

filter[car][owner][name][$eq]=John
filter[car][number_plate][$eq]=123456

Only 1 filter will be applied as the $this->model would be 'owner' when the second filter is attempted. This fix will restore the related model if it exists after applying the filter.