### PR TITLE
Fix: Update alias name used in `where`

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -72,6 +72,7 @@ export default defineUserConfig({
     docsBranch: 'master',
   }),
   plugins: [
+
     sitemapPlugin({
       hostname: 'https://abbasudo.github.io/laravel-purity',
     }),

--- a/src/Sorts/Strategies/HasOneSort.php
+++ b/src/Sorts/Strategies/HasOneSort.php
@@ -15,11 +15,12 @@ class HasOneSort extends SortAbstract
         $foreignKeyKey = $this->model->{$this->relationName}()->getQualifiedForeignKeyName();
         $localKey = $this->model->{$this->relationName}()->getQualifiedParentKeyName();
         $relatedTable = $relatedModel->getTable();
+        $foreignKeyKeyAlias = str($foreignKeyKey)->replace($relatedTable, $alias);
 
         return $this->query->orderBy(
             $relatedModel::query()
             ->select("{$relatedTable}.{$this->column}")
-            ->whereColumn($localKey, $foreignKeyKey)
+            ->whereColumn($localKeyAlias, $foreignKeyKeyAlias)
             ->orderByRaw("{$relatedTable}.{$this->column} {$this->direction}")
             ->limit(1),
             $this->direction


### PR DESCRIPTION
alternate the related table alias name causing the test to fail as it used the original name instead of the alias
```
 SortableTest::it_can_sort_by_has_one_relationship with data set #0 ('asc')
```